### PR TITLE
Fixes #33: Adds tweet search feature

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -64,4 +64,6 @@ dependencies {
     compile 'com.jakewharton.rxbinding2:rxbinding:2.0.0'
 
     compile 'com.github.LiquidPlayer:LiquidCore:0.2.2'
+
+    compile 'com.github.bumptech.glide:glide:3.7.0'
 }

--- a/app/src/main/java/org/loklak/android/adapters/SearchCategoryAdapter.java
+++ b/app/src/main/java/org/loklak/android/adapters/SearchCategoryAdapter.java
@@ -1,0 +1,119 @@
+package org.loklak.android.adapters;
+
+import android.content.Context;
+import android.support.v7.widget.RecyclerView;
+import android.support.v7.widget.StaggeredGridLayoutManager;
+import android.view.LayoutInflater;
+import android.view.View;
+import android.view.ViewGroup;
+import android.widget.ImageView;
+import android.widget.TextView;
+
+import com.bumptech.glide.Glide;
+
+import org.loklak.android.model.search.Status;
+import org.loklak.android.model.search.User;
+import org.loklak.android.wok.R;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import butterknife.BindView;
+import butterknife.ButterKnife;
+
+public class SearchCategoryAdapter
+        extends RecyclerView.Adapter<SearchCategoryAdapter.SearchViewHolder> {
+
+    private Context mContext;
+    private List<Status> mStatuses;
+
+    public SearchCategoryAdapter(Context context, List<Status> statuses) {
+        this.mContext = context;
+        this.mStatuses = statuses;
+    }
+
+    @Override
+    public SearchViewHolder onCreateViewHolder(ViewGroup parent, int viewType) {
+        View view = LayoutInflater.from(mContext).inflate(R.layout.row_tweet_search, parent, false);
+        return new SearchViewHolder(view);
+    }
+
+    @Override
+    public void onBindViewHolder(SearchViewHolder holder, int position) {
+        holder.bind(mStatuses.get(position));
+    }
+
+    @Override
+    public int getItemCount() {
+        return mStatuses.size();
+    }
+
+    public void setStatuses(List<Status> statuses) {
+        mStatuses = statuses;
+        notifyDataSetChanged();
+    }
+
+    class SearchViewHolder extends RecyclerView.ViewHolder {
+
+        @BindView(R.id.user_profile_pic)
+        ImageView userProfilePic;
+        @BindView(R.id.user_fullname)
+        TextView userFullname;
+        @BindView(R.id.tweet_date)
+        TextView tweetDate;
+        @BindView(R.id.username)
+        TextView username;
+        @BindView(R.id.tweet_text)
+        TextView tweetText;
+        @BindView(R.id.tweet_photos)
+        RecyclerView tweetPhotos;
+        @BindView(R.id.number_retweets)
+        TextView numberRetweets;
+        @BindView(R.id.number_likes)
+        TextView numberLikes;
+
+        SearchViewHolder(View itemView) {
+            super(itemView);
+            ButterKnife.bind(this, itemView);
+        }
+
+        void bind(Status status) {
+            User user = status.getUser();
+
+            Glide.with(mContext).load(user.getProfileImageUrlHttps()).into(userProfilePic);
+            userFullname.setText(user.getName());
+            username.setText(user.getScreenName());
+            tweetText.setText(status.getText());
+            numberRetweets.setText(String.valueOf(status.getRetweetCount()));
+            numberLikes.setText(String.valueOf(status.getFavouritesCount()));
+
+            List<String> imageUrls = filterImages(status.getImages());
+            int orientation = StaggeredGridLayoutManager.VERTICAL;
+            StaggeredGridLayoutManager layoutManager;
+            if (imageUrls.size() > 0) {
+                tweetPhotos.setVisibility(View.VISIBLE);
+                if (imageUrls.size() == 1) {
+                    layoutManager = new StaggeredGridLayoutManager(1, orientation);
+                } else {
+                    layoutManager = new StaggeredGridLayoutManager(2, orientation);
+                }
+                layoutManager.setGapStrategy(StaggeredGridLayoutManager.GAP_HANDLING_MOVE_ITEMS_BETWEEN_SPANS);
+                tweetPhotos.setLayoutManager(layoutManager);
+                TweetImagesAdapter tweetImagesAdapter = new TweetImagesAdapter(mContext, imageUrls);
+                tweetPhotos.setAdapter(tweetImagesAdapter);
+            } else {
+                tweetPhotos.setVisibility(View.GONE);
+            }
+        }
+
+        private List<String> filterImages(List<String> imageUrls) {
+            List<String> onlyPbsImages = new ArrayList<>();
+            for (String url: imageUrls) {
+                if (url.contains("pbs")) {
+                    onlyPbsImages.add(url);
+                }
+            }
+            return onlyPbsImages;
+        }
+    }
+}

--- a/app/src/main/java/org/loklak/android/adapters/SearchFragmentPagerAdapter.java
+++ b/app/src/main/java/org/loklak/android/adapters/SearchFragmentPagerAdapter.java
@@ -1,0 +1,38 @@
+package org.loklak.android.adapters;
+
+import android.support.v4.app.Fragment;
+import android.support.v4.app.FragmentManager;
+import android.support.v4.app.FragmentPagerAdapter;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class SearchFragmentPagerAdapter extends FragmentPagerAdapter {
+
+    private List<Fragment>  mFragmentList = new ArrayList<>();
+    private List<String> mFragmentNameList = new ArrayList<>();
+
+    public SearchFragmentPagerAdapter(FragmentManager fm) {
+        super(fm);
+    }
+
+    @Override
+    public Fragment getItem(int position) {
+        return mFragmentList.get(position);
+    }
+
+    @Override
+    public int getCount() {
+        return mFragmentList.size();
+    }
+
+    @Override
+    public CharSequence getPageTitle(int position) {
+        return mFragmentNameList.get(position);
+    }
+
+    public void addFragment(Fragment fragment, String pageTitle) {
+        mFragmentList.add(fragment);
+        mFragmentNameList.add(pageTitle);
+    }
+}

--- a/app/src/main/java/org/loklak/android/adapters/TweetImagesAdapter.java
+++ b/app/src/main/java/org/loklak/android/adapters/TweetImagesAdapter.java
@@ -1,0 +1,61 @@
+package org.loklak.android.adapters;
+
+import android.content.Context;
+import android.support.v7.widget.RecyclerView;
+import android.view.LayoutInflater;
+import android.view.View;
+import android.view.ViewGroup;
+import android.widget.ImageView;
+
+import com.bumptech.glide.Glide;
+
+import org.loklak.android.wok.R;
+
+import java.util.List;
+
+import butterknife.BindView;
+import butterknife.ButterKnife;
+
+public class TweetImagesAdapter extends
+        RecyclerView.Adapter<TweetImagesAdapter.TweetImagesViewHolder> {
+
+    private Context mContext;
+    private List<String> mImageUrls;
+
+    public TweetImagesAdapter(Context context, List<String> imageUrls) {
+        this.mContext = context;
+        this.mImageUrls = imageUrls;
+    }
+
+    @Override
+    public TweetImagesViewHolder onCreateViewHolder(ViewGroup parent, int viewType) {
+        LayoutInflater layoutInflater = LayoutInflater.from(mContext);
+        View view = layoutInflater.inflate(R.layout.grid_elem_tweet_photo, parent, false);
+        return new TweetImagesViewHolder(view);
+    }
+
+    @Override
+    public void onBindViewHolder(TweetImagesViewHolder holder, int position) {
+        holder.bind(mImageUrls.get(position));
+    }
+
+    @Override
+    public int getItemCount() {
+        return mImageUrls.size();
+    }
+
+    class TweetImagesViewHolder extends RecyclerView.ViewHolder {
+
+        @BindView(R.id.tweet_image)
+        ImageView tweetImage;
+
+        public TweetImagesViewHolder(View itemView) {
+            super(itemView);
+            ButterKnife.bind(this, itemView);
+        }
+
+        void bind(String imageUrl) {
+            Glide.with(mContext).load(imageUrl).fitCenter().into(tweetImage);
+        }
+    }
+}

--- a/app/src/main/java/org/loklak/android/api/LoklakApi.java
+++ b/app/src/main/java/org/loklak/android/api/LoklakApi.java
@@ -1,6 +1,9 @@
 package org.loklak.android.api;
 
+import android.support.annotation.Nullable;
+
 import org.loklak.android.model.harvest.Push;
+import org.loklak.android.model.search.Search;
 import org.loklak.android.model.suggest.SuggestData;
 
 import io.reactivex.Observable;
@@ -22,4 +25,10 @@ public interface LoklakApi {
     @POST("/api/push.json")
     @FormUrlEncoded
     Observable<Push> pushTweetsToLoklak(@Field("data") String data);
+
+    @GET("api/search.json")
+    Observable<Search> getSearchedTweets(
+            @Query("q") String query,
+            @Query("filter") String filter,
+            @Query("count") int count);
 }

--- a/app/src/main/java/org/loklak/android/model/search/Search.java
+++ b/app/src/main/java/org/loklak/android/model/search/Search.java
@@ -1,0 +1,16 @@
+package org.loklak.android.model.search;
+
+import java.util.List;
+import com.google.gson.annotations.Expose;
+import com.google.gson.annotations.SerializedName;
+
+public class Search {
+
+    private SearchMetadata mSearchMetadata;
+    private List<Status> mStatuses = null;
+    private List<String> aggregations;
+
+    public List<Status> getStatuses() {
+        return mStatuses;
+    }
+}

--- a/app/src/main/java/org/loklak/android/model/search/SearchMetadata.java
+++ b/app/src/main/java/org/loklak/android/model/search/SearchMetadata.java
@@ -1,0 +1,25 @@
+package org.loklak.android.model.search;
+
+
+import com.google.gson.annotations.SerializedName;
+
+public class SearchMetadata {
+
+    @SerializedName("startRecord")
+    private String mStartRecord;
+    @SerializedName("maximumRecords")
+    private String mMaximumRecords;
+    private String mCount;
+    private Integer mHits;
+    private Long mPeriod;
+    private String mQuery;
+    private String mFilter;
+    private String mClient;
+    private Integer mTime;
+    private Integer mCountTwitterAll;
+    private Integer mCountTwitterNew;
+    private Integer mCountBackend;
+    private Integer mCacheHits;
+    private String mIndex;
+
+}

--- a/app/src/main/java/org/loklak/android/model/search/Status.java
+++ b/app/src/main/java/org/loklak/android/model/search/Status.java
@@ -1,0 +1,63 @@
+package org.loklak.android.model.search;
+
+import java.util.List;
+
+public class Status {
+
+    private String mTimestamp;
+    private String mCreatedAt;
+    private String mScreenName;
+    private String mText;
+    private String mLink;
+    private String mIdStr;
+    private Integer mRetweetCount;
+    private Integer mFavouritesCount;
+    private List<String> mImages = null;
+    private List<String> mAudio = null;
+    private List<String> mVideos = null;
+    private User mUser;
+
+    public String getTimestamp() {
+        return mTimestamp;
+    }
+
+    public String getCreatedAt() {
+        return mCreatedAt;
+    }
+
+    public String getText() {
+        return mText;
+    }
+
+    public String getLink() {
+        return mLink;
+    }
+
+    public String getIdStr() {
+        return mIdStr;
+    }
+
+    public Integer getRetweetCount() {
+        return mRetweetCount;
+    }
+
+    public Integer getFavouritesCount() {
+        return mFavouritesCount;
+    }
+
+    public List<String> getImages() {
+        return mImages;
+    }
+
+    public List<String> getAudio() {
+        return mAudio;
+    }
+
+    public List<String> getVideos() {
+        return mVideos;
+    }
+
+    public User getUser() {
+        return mUser;
+    }
+}

--- a/app/src/main/java/org/loklak/android/model/search/User.java
+++ b/app/src/main/java/org/loklak/android/model/search/User.java
@@ -1,0 +1,25 @@
+package org.loklak.android.model.search;
+
+public class User {
+
+    private String mProfileImageUrlHttps;
+    private String mScreenName;
+    private String mUserId;
+    private String mName;
+
+    public String getProfileImageUrlHttps() {
+        return mProfileImageUrlHttps;
+    }
+
+    public String getScreenName() {
+        return mScreenName;
+    }
+
+    public String getUserId() {
+        return mUserId;
+    }
+
+    public String getName() {
+        return mName;
+    }
+}

--- a/app/src/main/java/org/loklak/android/ui/fragment/SearchCategoryFragment.java
+++ b/app/src/main/java/org/loklak/android/ui/fragment/SearchCategoryFragment.java
@@ -1,0 +1,124 @@
+package org.loklak.android.ui.fragment;
+
+
+import android.content.res.Resources;
+import android.os.Bundle;
+import android.support.annotation.Nullable;
+import android.support.v4.app.Fragment;
+import android.support.v7.widget.LinearLayoutManager;
+import android.support.v7.widget.RecyclerView;
+import android.util.Log;
+import android.view.LayoutInflater;
+import android.view.View;
+import android.view.ViewGroup;
+import android.widget.TextView;
+
+import org.loklak.android.adapters.SearchCategoryAdapter;
+import org.loklak.android.api.LoklakApi;
+import org.loklak.android.api.RestClient;
+import org.loklak.android.model.search.Search;
+import org.loklak.android.model.search.Status;
+import org.loklak.android.utility.Constants;
+import org.loklak.android.wok.R;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import butterknife.BindView;
+import butterknife.ButterKnife;
+import butterknife.OnClick;
+import io.reactivex.android.schedulers.AndroidSchedulers;
+import io.reactivex.schedulers.Schedulers;
+
+public class SearchCategoryFragment extends Fragment {
+
+    private static final String TWEET_SEARCH_CATEGORY_KEY = "tweet-search-category";
+    private final String LOG_TAG = SearchCategoryFragment.class.getName();
+
+    @BindView(R.id.searched_tweet_container)
+    RecyclerView recyclerView;
+    @BindView(R.id.no_search_result_found)
+    TextView noSearchResultFoundTextView;
+    @BindView(R.id.network_error)
+    TextView networkErrorTextView;
+
+    private SearchCategoryAdapter mSearchCategoryAdapter;
+
+    private String mSearchQuery;
+    private String mTweetSearchCategory;
+
+    public SearchCategoryFragment() {
+        // Required empty public constructor
+    }
+
+    public static SearchCategoryFragment newInstance(String category, String query) {
+        Bundle args = new Bundle();
+        args.putString(Constants.TWEET_SEARCH_SUGGESTION_QUERY_KEY, query);
+        args.putString(TWEET_SEARCH_CATEGORY_KEY, category);
+        SearchCategoryFragment fragment = new SearchCategoryFragment();
+        fragment.setArguments(args);
+        return fragment;
+    }
+
+    @Override
+    public void onCreate(@Nullable Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+        Bundle bundle = getArguments();
+        if (bundle != null) {
+            mTweetSearchCategory = bundle.getString(TWEET_SEARCH_CATEGORY_KEY);
+            mSearchQuery = bundle.getString(Constants.TWEET_SEARCH_SUGGESTION_QUERY_KEY);
+        }
+    }
+
+    @Override
+    public View onCreateView(LayoutInflater inflater, ViewGroup container,
+                             Bundle savedInstanceState) {
+        // Inflate the layout for this fragment
+        View view = inflater.inflate(R.layout.fragment_search_category, container, false);
+        ButterKnife.bind(this, view);
+
+        mSearchCategoryAdapter = new SearchCategoryAdapter(getActivity(), new ArrayList<>());
+        recyclerView.setAdapter(mSearchCategoryAdapter);
+        recyclerView.setLayoutManager(new LinearLayoutManager(getActivity()));
+
+        fetchSearchedTweets();
+
+        return view;
+    }
+
+    private void fetchSearchedTweets() {
+        LoklakApi loklakApi = RestClient.createApi(LoklakApi.class);
+        loklakApi.getSearchedTweets(mSearchQuery, mTweetSearchCategory, 30)
+                .subscribeOn(Schedulers.io())
+                .observeOn(AndroidSchedulers.mainThread())
+                .subscribe(this::setSearchResultView, this::setNetworkErrorView);
+    }
+
+    private void setSearchResultView(Search search) {
+        List<Status> statusList = search.getStatuses();
+        networkErrorTextView.setVisibility(View.GONE);
+        if (statusList.size() == 0) {
+            recyclerView.setVisibility(View.GONE);
+
+            Resources res = getResources();
+            String noSearchResultMessage = res.getString(R.string.no_search_match, mSearchQuery);
+            noSearchResultFoundTextView.setVisibility(View.VISIBLE);
+            noSearchResultFoundTextView.setText(noSearchResultMessage);
+        } else {
+            recyclerView.setVisibility(View.VISIBLE);
+            mSearchCategoryAdapter.setStatuses(statusList);
+        }
+    }
+
+    private void setNetworkErrorView(Throwable throwable) {
+        Log.e(LOG_TAG, throwable.toString());
+        recyclerView.setVisibility(View.GONE);
+        networkErrorTextView.setVisibility(View.VISIBLE);
+    }
+
+    @OnClick(R.id.network_error)
+    public void setOnClickNetworkErrorTextViewListener(View view) {
+        networkErrorTextView.setVisibility(View.GONE);
+        fetchSearchedTweets();
+    }
+}

--- a/app/src/main/java/org/loklak/android/ui/fragment/SearchFragment.java
+++ b/app/src/main/java/org/loklak/android/ui/fragment/SearchFragment.java
@@ -1,30 +1,96 @@
 package org.loklak.android.ui.fragment;
 
 
+import android.content.Intent;
 import android.os.Bundle;
+import android.support.design.widget.TabLayout;
 import android.support.v4.app.Fragment;
+import android.support.v4.app.FragmentManager;
+import android.support.v4.view.ViewPager;
+import android.support.v7.app.AppCompatActivity;
+import android.support.v7.widget.Toolbar;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
+import android.widget.EditText;
+import android.widget.ImageButton;
 
+import org.loklak.android.adapters.SearchFragmentPagerAdapter;
+import org.loklak.android.ui.activity.SuggestActivity;
+import org.loklak.android.utility.Constants;
 import org.loklak.android.wok.R;
 
-/**
- * A simple {@link Fragment} subclass.
- */
+import butterknife.BindView;
+import butterknife.ButterKnife;
+import butterknife.OnClick;
+
+
 public class SearchFragment extends Fragment {
 
+    private final String LOG_TAG = SearchFragment.class.getName();
+
+    @BindView(R.id.toolbar)
+    Toolbar toolbar;
+    @BindView(R.id.tweet_search_edit_text)
+    EditText tweetSearchEditText;
+    @BindView(R.id.clear_image_button)
+    ImageButton clearImageButton;
+    @BindView(R.id.tabs)
+    TabLayout tabLayout;
+    @BindView(R.id.view_pager)
+    ViewPager viewPager;
+
+    private String mQuery;
 
     public SearchFragment() {
         // Required empty public constructor
     }
 
-
     @Override
     public View onCreateView(LayoutInflater inflater, ViewGroup container,
                              Bundle savedInstanceState) {
         // Inflate the layout for this fragment
-        return inflater.inflate(R.layout.fragment_search, container, false);
+        View rootView = inflater.inflate(R.layout.fragment_search, container, false);
+        ButterKnife.bind(this, rootView);
+
+        AppCompatActivity appCompatActivity = (AppCompatActivity) getActivity();
+        appCompatActivity.setSupportActionBar(toolbar);
+        toolbar.setNavigationIcon(R.drawable.ic_arrow_back_24dp);
+        toolbar.setNavigationOnClickListener(view -> getActivity().onBackPressed());
+
+        Intent intent = getActivity().getIntent();
+        mQuery = intent.getStringExtra(Constants.TWEET_SEARCH_SUGGESTION_QUERY_KEY);
+        tweetSearchEditText.setOnFocusChangeListener((view, hasFocus) -> {
+            if (hasFocus) {
+                Intent suggestIntent = new Intent(getActivity(), SuggestActivity.class);
+                startActivity(suggestIntent);
+            }
+        });
+
+        tabLayout.setupWithViewPager(viewPager);
+        setupViewPager(viewPager);
+
+        return rootView;
     }
 
+    @Override
+    public void onStart() {
+        super.onStart();
+        tweetSearchEditText.setText(mQuery);
+    }
+
+    private void setupViewPager(ViewPager viewPager) {
+        FragmentManager fragmentManager = getActivity().getSupportFragmentManager();
+        SearchFragmentPagerAdapter pagerAdapter = new SearchFragmentPagerAdapter(fragmentManager);
+        pagerAdapter.addFragment(SearchCategoryFragment.newInstance("", mQuery), "LATEST");
+        pagerAdapter.addFragment(SearchCategoryFragment.newInstance("image", mQuery), "PHOTOS");
+        pagerAdapter.addFragment(SearchCategoryFragment.newInstance("video", mQuery), "VIDEOS");
+        viewPager.setAdapter(pagerAdapter);
+    }
+
+    @OnClick(R.id.clear_image_button)
+    public void setOnClickClearImageButtonListener(View view) {
+        tweetSearchEditText.setText("");
+        tweetSearchEditText.clearFocus();
+    }
 }

--- a/app/src/main/res/drawable/heart.xml
+++ b/app/src/main/res/drawable/heart.xml
@@ -1,0 +1,8 @@
+<!-- drawable/heart.xml -->
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:height="24dp"
+    android:width="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <path android:fillColor="#666666" android:pathData="M12,21.35L10.55,20.03C5.4,15.36 2,12.27 2,8.5C2,5.41 4.42,3 7.5,3C9.24,3 10.91,3.81 12,5.08C13.09,3.81 14.76,3 16.5,3C19.58,3 22,5.41 22,8.5C22,12.27 18.6,15.36 13.45,20.03L12,21.35Z" />
+</vector>

--- a/app/src/main/res/drawable/reply.xml
+++ b/app/src/main/res/drawable/reply.xml
@@ -1,0 +1,8 @@
+<!-- drawable/reply.xml -->
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:height="24dp"
+    android:width="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <path android:fillColor="#666666" android:pathData="M10,9V5L3,12L10,19V14.9C15,14.9 18.5,16.5 21,20C20,15 17,10 10,9Z" />
+</vector>

--- a/app/src/main/res/drawable/retweet.xml
+++ b/app/src/main/res/drawable/retweet.xml
@@ -1,0 +1,8 @@
+<!-- drawable/twitter_retweet.xml -->
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:height="24dp"
+    android:width="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <path android:fillColor="#666666" android:pathData="M6,5.75L10.25,10H7V16H13.5L15.5,18H7A2,2 0 0,1 5,16V10H1.75L6,5.75M18,18.25L13.75,14H17V8H10.5L8.5,6H17A2,2 0 0,1 19,8V14H22.25L18,18.25Z" />
+</vector>

--- a/app/src/main/res/layout/fragment_search.xml
+++ b/app/src/main/res/layout/fragment_search.xml
@@ -1,11 +1,57 @@
-<FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<RelativeLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     tools:context="org.loklak.android.ui.fragment.SearchFragment">
 
-    <TextView
+    <android.support.design.widget.AppBarLayout
         android:layout_width="match_parent"
-        android:layout_height="match_parent" />
+        android:layout_height="wrap_content"
+        android:id="@+id/app_bar_layout">
+        
+        <android.support.v7.widget.Toolbar
+            android:layout_width="match_parent"
+            android:layout_height="?attr/actionBarSize"
+            android:id="@+id/toolbar">
 
-</FrameLayout>
+            <LinearLayout
+                android:layout_width="match_parent"
+                android:layout_height="match_parent"
+                android:focusableInTouchMode="true">
+
+                <EditText
+                    android:layout_width="0dp"
+                    android:layout_height="match_parent"
+                    android:layout_weight="1"
+                    android:id="@+id/tweet_search_edit_text"
+                    android:inputType="textAutoComplete"
+                    android:hint="@string/tweet_search_edit_text_hint"
+                    android:background="@android:color/transparent" />
+
+                <ImageButton
+                    android:layout_width="@dimen/clear_image_button_width"
+                    android:layout_height="match_parent"
+                    android:id="@+id/clear_image_button"
+                    android:contentDescription="@string/clear_image_desc"
+                    android:src="@drawable/ic_close_24dp"
+                    android:background="@android:color/transparent"/>
+
+            </LinearLayout>
+
+        </android.support.v7.widget.Toolbar>
+
+        <android.support.design.widget.TabLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:id="@+id/tabs"/>
+
+    </android.support.design.widget.AppBarLayout>
+    
+    <android.support.v4.view.ViewPager
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:id="@+id/view_pager"
+        android:layout_below="@id/app_bar_layout"/>
+
+</RelativeLayout>

--- a/app/src/main/res/layout/fragment_search_category.xml
+++ b/app/src/main/res/layout/fragment_search_category.xml
@@ -1,0 +1,40 @@
+<RelativeLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    tools:context="org.loklak.android.ui.fragment.SearchCategoryFragment">
+
+    <android.support.v7.widget.RecyclerView
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:id="@+id/searched_tweet_container" />
+
+    <TextView
+        android:layout_width="@dimen/message_width"
+        android:layout_height="wrap_content"
+        android:id="@+id/no_search_result_found"
+        android:layout_centerInParent="true"
+        android:padding="@dimen/message_padding"
+        android:gravity="center"
+        android:textSize="@dimen/message_font_size"
+        android:textStyle="bold"
+        android:textColor="@android:color/black"
+        android:maxLines="4"
+        android:ellipsize="end"
+        android:visibility="gone"/>
+
+    <TextView
+        android:layout_width="@dimen/message_width"
+        android:layout_height="wrap_content"
+        android:id="@+id/network_error"
+        android:padding="@dimen/message_padding"
+        android:gravity="center"
+        android:layout_centerInParent="true"
+        android:text="@string/network_error_retry"
+        android:textSize="@dimen/message_font_size"
+        android:textStyle="bold"
+        android:textColor="@android:color/black"
+        android:visibility="gone"/>
+
+</RelativeLayout>

--- a/app/src/main/res/layout/fragment_tweet_harvesting.xml
+++ b/app/src/main/res/layout/fragment_tweet_harvesting.xml
@@ -45,15 +45,16 @@
         android:layout_marginTop="@dimen/tweet_harvesting_margin"/>
 
     <TextView
-        android:layout_width="@dimen/network_error_message_width"
+        android:layout_width="@dimen/message_width"
         android:layout_height="wrap_content"
         android:id="@+id/network_error"
-        android:padding="@dimen/network_error_padding"
+        android:padding="@dimen/message_padding"
         android:gravity="center"
         android:layout_centerHorizontal="true"
         android:layout_centerVertical="true"
         android:text="@string/network_error_retry"
         android:textSize="@dimen/message_font_size"
+        android:textStyle="bold"
         android:textColor="@android:color/black"
         android:visibility="gone"/>
 

--- a/app/src/main/res/layout/grid_elem_tweet_photo.xml
+++ b/app/src/main/res/layout/grid_elem_tweet_photo.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="utf-8"?>
+<FrameLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent">
+
+    <ImageView
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:id="@+id/tweet_image"/>
+
+</FrameLayout>

--- a/app/src/main/res/layout/row_harvested_tweet.xml
+++ b/app/src/main/res/layout/row_harvested_tweet.xml
@@ -2,13 +2,16 @@
 <android.support.v7.widget.CardView xmlns:android="http://schemas.android.com/apk/res/android"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
-    android:layout_margin="8dp">
+    android:layout_marginLeft="@dimen/recycler_view_row_left_right_margin"
+    android:layout_marginRight="@dimen/recycler_view_row_left_right_margin"
+    android:layout_marginTop="@dimen/recycler_view_row_top_bottom_margin"
+    android:layout_marginBottom="@dimen/recycler_view_row_top_bottom_margin">
 
     <LinearLayout
         android:orientation="vertical"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:padding="8dp">
+        android:padding="@dimen/recycler_view_row_padding">
 
         <LinearLayout
             android:layout_width="match_parent"

--- a/app/src/main/res/layout/row_tweet_search.xml
+++ b/app/src/main/res/layout/row_tweet_search.xml
@@ -1,0 +1,135 @@
+<?xml version="1.0" encoding="utf-8"?>
+<android.support.v7.widget.CardView xmlns:android="http://schemas.android.com/apk/res/android"
+    android:orientation="vertical"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:layout_marginLeft="@dimen/recycler_view_row_left_right_margin"
+    android:layout_marginRight="@dimen/recycler_view_row_left_right_margin"
+    android:layout_marginTop="@dimen/recycler_view_row_top_bottom_margin"
+    android:layout_marginBottom="@dimen/recycler_view_row_top_bottom_margin">
+
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:padding="@dimen/recycler_view_row_padding">
+
+        <ImageView
+            android:layout_width="@dimen/profile_pic_side"
+            android:layout_height="@dimen/profile_pic_side"
+            android:id="@+id/user_profile_pic"/>
+
+        <LinearLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:orientation="vertical"
+            android:layout_marginLeft="8dp">
+
+            <LinearLayout
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content">
+
+                <TextView
+                    android:layout_width="0dp"
+                    android:layout_height="wrap_content"
+                    android:layout_weight="1"
+                    android:id="@+id/user_fullname"
+                    android:textColor="@android:color/black"
+                    android:textStyle="bold"
+                    android:maxLines="1"
+                    android:ellipsize="end"/>
+
+                <TextView
+                    android:layout_width="0dp"
+                    android:layout_height="wrap_content"
+                    android:layout_weight="1"
+                    android:id="@+id/username"
+                    android:maxLines="1"
+                    android:ellipsize="end"/>
+
+                <TextView
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:id="@+id/tweet_date" />
+
+            </LinearLayout>
+
+            <TextView
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:id="@+id/tweet_text"
+                android:textColor="@android:color/black"
+                android:layout_marginTop="8dp" />
+            
+            <android.support.v7.widget.RecyclerView
+                android:layout_width="match_parent"
+                android:layout_height="160dp"
+                android:id="@+id/tweet_photos"
+                android:layout_marginTop="8dp" />
+
+            <LinearLayout
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="8dp">
+
+                <LinearLayout
+                    android:layout_width="0dp"
+                    android:layout_height="wrap_content"
+                    android:layout_weight="1"
+                    android:gravity="center">
+
+                    <ImageView
+                        android:layout_width="24dp"
+                        android:layout_height="24dp"
+                        android:src="@drawable/reply"/>
+
+                </LinearLayout>
+
+                <LinearLayout
+                    android:layout_width="0dp"
+                    android:layout_height="wrap_content"
+                    android:layout_weight="1"
+                    android:gravity="center">
+
+                    <ImageView
+                        android:layout_width="24dp"
+                        android:layout_height="24dp"
+                        android:src="@drawable/retweet"/>
+
+                    <TextView
+                        android:layout_width="24dp"
+                        android:layout_height="24dp"
+                        android:id="@+id/number_retweets"
+                        android:layout_marginLeft="4dp"
+                        android:gravity="center"
+                        android:text="0"/>
+
+                </LinearLayout>
+
+                <LinearLayout
+                    android:layout_width="0dp"
+                    android:layout_height="wrap_content"
+                    android:layout_weight="1"
+                    android:gravity="center">
+
+                    <ImageView
+                        android:layout_width="24dp"
+                        android:layout_height="24dp"
+                        android:src="@drawable/heart"/>
+
+                    <TextView
+                        android:layout_width="24dp"
+                        android:layout_height="24dp"
+                        android:id="@+id/number_likes"
+                        android:layout_marginLeft="4dp"
+                        android:gravity="center"
+                        android:text="0"/>
+
+                </LinearLayout>
+
+            </LinearLayout>
+
+        </LinearLayout>
+
+    </LinearLayout>
+
+</android.support.v7.widget.CardView>

--- a/app/src/main/res/values/dimens.xml
+++ b/app/src/main/res/values/dimens.xml
@@ -1,18 +1,22 @@
 <resources>
     <!-- Default screen margins, per the Android Design guidelines. -->
     <dimen name="divider_height">1dp</dimen>
+    <dimen name="recycler_view_row_left_right_margin">8dp</dimen>
+    <dimen name="recycler_view_row_top_bottom_margin">4dp</dimen>
+    <dimen name="recycler_view_row_padding">8dp</dimen>
+    <dimen name="message_font_size">24sp</dimen>
+    <dimen name="message_padding">24dp</dimen>
+    <dimen name="message_width">240dp</dimen>
+    <dimen name="clear_image_button_width">48dp</dimen>
 
     <!-- row_tweet_search_suggest -->
     <dimen name="suggest_query_font_size">20sp</dimen>
     <dimen name="suggest_query_padding">24dp</dimen>
 
-    <!-- fragment_suggest -->
-    <dimen name="clear_image_button_width">48dp</dimen>
-
     <!-- fragment_tweet_harvesting -->
     <dimen name="tweet_harvesting_margin">8dp</dimen>
     <dimen name="tweets_harvested_count">40sp</dimen>
-    <dimen name="message_font_size">16sp</dimen>
-    <dimen name="network_error_padding">24dp</dimen>
-    <dimen name="network_error_message_width">240dp</dimen>
+
+    <!-- row_tweet_search -->
+    <dimen name="profile_pic_side">48dp</dimen>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1,14 +1,16 @@
 <resources>
     <string name="app_name">Loklak wok</string>
-
-    <!-- fragment_suggest -->
+    <string name="network_error_retry">Please check your internet connection. Tap here to try again!</string>
     <string name="tweet_search_edit_text_hint">Search Twitter</string>
-    <string name="network_request_error">Cannot fetch suggestions, Try Again!</string>
     <string name="clear_image_desc">Clears Search EditText for a new search</string>
 
+    <!-- fragment_suggest -->
+    <string name="network_request_error">Cannot fetch suggestions, Try Again!</string>
+
     <!-- fragment_tweet_harvesting -->
-    <string name="network_error_retry">Couldn\'t scrape data. Click here to try again!</string>
     <string name="zero_tweets">0</string>
     <string name="count_message">TWEETS HARVESTED</string>
 
+    <!-- fragment_search_category -->
+    <string name="no_search_match">No results for \"%1$s\"</string>
 </resources>


### PR DESCRIPTION
Related issue: https://github.com/fossasia/loklak_wok_android/issues/33

The search query is obtained from the intent received from
SuggestFragment. Using the "search" API endpoint of loklak tweets are
obtained and inflated. Tweets are displayed in three different
categories i.e. "LATEST", "PHOTOS" and "VIDEOS". This is done by using
"filter" parameter in "search" endpoint and by using TabLayouts and
ViewPager to provide the UI. Boundary cases like:
1. No tweets found for the query and
2. Network error
are handled by changing the visibility of RecyclerView to GONE and the
message to be shown to VISIBLE.