### PR TITLE
Fixes #56: Logout users from twitter

### DIFF
--- a/app/src/main/java/org/loklak/android/utility/SharedPrefUtil.java
+++ b/app/src/main/java/org/loklak/android/utility/SharedPrefUtil.java
@@ -25,4 +25,8 @@ public class SharedPrefUtil {
         editor.remove(key);
         editor.commit();
     }
+
+    public static void clearSharedPrefData(Context context) {
+        PreferenceManager.getDefaultSharedPreferences(context).edit().clear().apply();
+    }
 }

--- a/app/src/main/res/layout/fragment_tweet_posting.xml
+++ b/app/src/main/res/layout/fragment_tweet_posting.xml
@@ -7,13 +7,12 @@
 
     <android.support.design.widget.AppBarLayout
         android:layout_width="match_parent"
-        android:layout_height="wrap_content">
+        android:layout_height="?attr/actionBarSize">
 
         <android.support.v7.widget.Toolbar
             android:layout_width="match_parent"
             android:layout_height="?attr/actionBarSize"
-            android:id="@+id/toolbar">
-        </android.support.v7.widget.Toolbar>
+            android:id="@+id/toolbar"/>
 
     </android.support.design.widget.AppBarLayout>
 

--- a/app/src/main/res/menu/menu_tweet_posting.xml
+++ b/app/src/main/res/menu/menu_tweet_posting.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<menu xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto">
+
+    <item
+        android:title="Logout"
+        app:showAsAction="never"
+        android:id="@+id/logout" />
+</menu>


### PR DESCRIPTION
Solves issue: https://github.com/fossasia/loklak_wok_android/issues/56
Removes OAuth credentials from shared preferences when clicked on "Logout" option and finishes the activity. Upon successful authorization menu is populated again with "Logout" option.