### PR TITLE
Fixes #59: Single Activity type, in activity stack

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -43,13 +43,17 @@
 
         <activity
             android:name="org.loklak.android.ui.activity.SuggestActivity"
-            android:windowSoftInputMode="stateHidden|adjustResize"/>
+            android:windowSoftInputMode="stateHidden|adjustResize"
+            android:launchMode="singleTask"/>
 
-        <activity android:name="org.loklak.android.ui.activity.SearchActivity" />
+        <activity
+            android:name="org.loklak.android.ui.activity.SearchActivity"
+            android:launchMode="singleTask"/>
 
         <activity
             android:name="org.loklak.android.ui.activity.TweetPostingActivity"
-            android:windowSoftInputMode="adjustResize|stateHidden"/>
+            android:windowSoftInputMode="adjustResize|stateHidden"
+            android:launchMode="singleTask"/>
 
         <!-- TODO: uncomment the following, add API key and uncomment Fabric crashlytics kit in
         LoklakWokApplication -->


### PR DESCRIPTION
Launch mode of Search, Suggest and Posting activity is changed to single
task. This way only a single activity of its type will be present in
activity back-stack resulting in less memory use.