### PR TITLE
Fixes #62: Adds touch selectors for buttons

### DIFF
--- a/app/src/main/res/drawable/media_button_selector.xml
+++ b/app/src/main/res/drawable/media_button_selector.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<selector xmlns:android="http://schemas.android.com/apk/res/android">
+
+    <item android:drawable="@color/media_button_touch_selector_backgroud" android:state_pressed="true"/>
+    <item android:drawable="@color/media_button_touch_selector_backgroud" android:state_activated="true"/>
+    <item android:drawable="@color/media_button_touch_selector_backgroud" android:state_selected="true"/>
+
+    <item android:drawable="@android:color/transparent"/>
+</selector>

--- a/app/src/main/res/drawable/tweet_button_selector.xml
+++ b/app/src/main/res/drawable/tweet_button_selector.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<selector xmlns:android="http://schemas.android.com/apk/res/android">
+
+    <item android:drawable="@color/colorAccentLight" android:state_pressed="true"/>
+    <item android:drawable="@color/colorAccentLight" android:state_activated="true"/>
+    <item android:drawable="@color/colorAccentLight" android:state_selected="true"/>
+
+    <item android:drawable="@color/colorAccent"/>
+</selector>

--- a/app/src/main/res/layout/fragment_tweet_posting.xml
+++ b/app/src/main/res/layout/fragment_tweet_posting.xml
@@ -77,7 +77,7 @@
             android:id="@+id/camera"
             android:src="@drawable/camera"
             android:contentDescription="@string/camera_description"
-            android:background="@android:color/transparent" />
+            android:background="@drawable/media_button_selector" />
 
         <ImageButton
             android:layout_width="@dimen/tweet_posting_image_button_side"
@@ -86,7 +86,7 @@
             android:id="@+id/gallery"
             android:src="@drawable/ic_gallery_24dp"
             android:contentDescription="@string/gallery_description"
-            android:background="@android:color/transparent" />
+            android:background="@drawable/media_button_selector" />
 
         <ImageButton
             android:layout_width="@dimen/tweet_posting_image_button_side"
@@ -95,7 +95,7 @@
             android:id="@+id/location"
             android:src="@drawable/ic_add_location_24dp"
             android:contentDescription="@string/location_description"
-            android:background="@android:color/transparent" />
+            android:background="@drawable/media_button_selector" />
 
         <TextView
             android:layout_width="@dimen/tweet_posting_image_button_side"
@@ -115,7 +115,7 @@
             android:text="@string/tweet_post_button_text"
             android:textSize="@dimen/tweet_post_button_text_font_size"
             android:textColor="@android:color/white"
-            android:background="@color/colorAccent" />
+            android:background="@drawable/tweet_button_selector" />
 
     </LinearLayout>
 

--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -3,8 +3,12 @@
     <color name="colorPrimary">#FFFFFF</color>
     <color name="colorPrimaryDark">#C2185B</color>
     <color name="colorAccent">#E91E63</color>
+    <color name="colorAccentLight">#F48FB1</color>
     <color name="secondary_text_material_light">#757575</color>
 
     <!-- Divider color -->
     <color name="divider_color">#BDBDBD</color>
+
+    <!-- Touch selector color -->
+    <color name="media_button_touch_selector_backgroud">#BDBDBD</color>
 </resources>


### PR DESCRIPTION
Adds touch selector for media buttons and tweet button in
TweetPostingFragment. The media buttons have the background "#BDBDBD"
and tweet button has the background "#F48FB1" which is also the light
accent color.
![20915720_1929423730678351_602372633_n](https://user-images.githubusercontent.com/12163892/29419124-e89f1b64-838b-11e7-85f1-8585e3a55390.gif)
