### PR TITLE
Fixes #71: Adds circular progress bar

### DIFF
--- a/app/src/main/java/org/loklak/wok/ui/fragment/SearchCategoryFragment.java
+++ b/app/src/main/java/org/loklak/wok/ui/fragment/SearchCategoryFragment.java
@@ -12,6 +12,7 @@ import android.util.Log;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
+import android.widget.ProgressBar;
 import android.widget.TextView;
 
 import org.loklak.wok.adapters.SearchCategoryAdapter;
@@ -40,6 +41,8 @@ public class SearchCategoryFragment extends Fragment {
 
     @BindView(R.id.searched_tweet_container)
     RecyclerView recyclerView;
+    @BindView(R.id.progress_bar)
+    ProgressBar progressBar;
     @BindView(R.id.no_search_result_found)
     TextView noSearchResultFoundTextView;
     @BindView(R.id.network_error)
@@ -90,10 +93,12 @@ public class SearchCategoryFragment extends Fragment {
             List<Status> searchedTweets =
                     savedInstanceState.getParcelableArrayList(PARCELABLE_SEARCHED_TWEETS);
             mSearchCategoryAdapter.setStatuses(searchedTweets);
+            progressBar.setVisibility(View.GONE);
+            recyclerView.setVisibility(View.VISIBLE);
+        } else {
+            fetchSearchedTweets();
         }
         recyclerView.setAdapter(mSearchCategoryAdapter);
-
-        fetchSearchedTweets();
 
         return view;
     }
@@ -109,6 +114,7 @@ public class SearchCategoryFragment extends Fragment {
     }
 
     private void fetchSearchedTweets() {
+        progressBar.setVisibility(View.VISIBLE);
         LoklakApi loklakApi = RestClient.createApi(LoklakApi.class);
         loklakApi.getSearchedTweets(mSearchQuery, mTweetSearchCategory, 30)
                 .subscribeOn(Schedulers.io())
@@ -119,6 +125,7 @@ public class SearchCategoryFragment extends Fragment {
     private void setSearchResultView(Search search) {
         List<Status> statusList = search.getStatuses();
         networkErrorTextView.setVisibility(View.GONE);
+        progressBar.setVisibility(View.GONE);
         if (statusList.size() == 0) {
             recyclerView.setVisibility(View.GONE);
 
@@ -134,6 +141,7 @@ public class SearchCategoryFragment extends Fragment {
 
     private void setNetworkErrorView(Throwable throwable) {
         Log.e(LOG_TAG, throwable.toString());
+        progressBar.setVisibility(View.GONE);
         recyclerView.setVisibility(View.GONE);
         networkErrorTextView.setVisibility(View.VISIBLE);
     }

--- a/app/src/main/java/org/loklak/wok/ui/fragment/TweetHarvestingFragment.java
+++ b/app/src/main/java/org/loklak/wok/ui/fragment/TweetHarvestingFragment.java
@@ -16,6 +16,7 @@ import android.view.MenuInflater;
 import android.view.MenuItem;
 import android.view.View;
 import android.view.ViewGroup;
+import android.widget.ProgressBar;
 import android.widget.TextView;
 
 import com.google.gson.Gson;
@@ -74,6 +75,8 @@ public class TweetHarvestingFragment extends Fragment {
     TextView harvestedTweetsCountTextView;
     @BindView(R.id.harvested_tweets_container)
     RecyclerView recyclerView;
+    @BindView(R.id.progress_bar)
+    ProgressBar progressBar;
     @BindView(R.id.network_error)
     TextView networkErrorTextView;
 
@@ -166,6 +169,7 @@ public class TweetHarvestingFragment extends Fragment {
         super.onStart();
         mSuggestionQuerries.clear();
         mCompositeDisposable = new CompositeDisposable();
+        recyclerView.setVisibility(View.GONE);
         displayAndPostScrapedData();
     }
 
@@ -268,6 +272,8 @@ public class TweetHarvestingFragment extends Fragment {
     }
 
     private void displayScrapedData(ScrapedData scrapedData) {
+        progressBar.setVisibility(View.GONE);
+        recyclerView.setVisibility(View.VISIBLE);
         String query = scrapedData.getQuery();
         List<Status> statuses = scrapedData.getStatuses();
         mSuggestionQuerries.remove(query);
@@ -282,6 +288,7 @@ public class TweetHarvestingFragment extends Fragment {
     private void setNetworkErrorView(Throwable throwable) {
         Log.e(LOG_TAG, throwable.toString());
         ButterKnife.apply(networkViews, GONE);
+        progressBar.setVisibility(View.GONE);
         networkErrorTextView.setVisibility(View.VISIBLE);
     }
 
@@ -296,6 +303,7 @@ public class TweetHarvestingFragment extends Fragment {
     }
 
     private void displayAndPostScrapedData() {
+        progressBar.setVisibility(View.VISIBLE);
         ConnectableObservable<ScrapedData> observable = Observable.interval(4, TimeUnit.SECONDS)
                 .flatMap(this::getSuggestionsPeriodically)
                 .flatMap(query -> {

--- a/app/src/main/res/layout/fragment_search_category.xml
+++ b/app/src/main/res/layout/fragment_search_category.xml
@@ -5,10 +5,17 @@
     android:layout_height="match_parent"
     tools:context="org.loklak.wok.ui.fragment.SearchCategoryFragment">
 
+    <ProgressBar
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:id="@+id/progress_bar"
+        android:layout_centerInParent="true" />
+
     <android.support.v7.widget.RecyclerView
         android:layout_width="match_parent"
         android:layout_height="match_parent"
-        android:id="@+id/searched_tweet_container" />
+        android:id="@+id/searched_tweet_container"
+        android:visibility="gone"/>
 
     <TextView
         android:layout_width="@dimen/message_width"

--- a/app/src/main/res/layout/fragment_tweet_harvesting.xml
+++ b/app/src/main/res/layout/fragment_tweet_harvesting.xml
@@ -38,12 +38,25 @@
         android:text="@string/count_message"
         android:textSize="@dimen/message_font_size"/>
 
-    <android.support.v7.widget.RecyclerView
+    <RelativeLayout
         android:layout_width="match_parent"
         android:layout_height="match_parent"
-        android:id="@+id/harvested_tweets_container"
-        android:layout_below="@id/harvested__tweet_count_message"
-        android:layout_marginTop="@dimen/tweet_harvesting_margin"/>
+        android:layout_below="@id/harvested__tweet_count_message">
+
+        <android.support.v7.widget.RecyclerView
+            android:layout_width="match_parent"
+            android:layout_height="match_parent"
+            android:id="@+id/harvested_tweets_container"
+            android:layout_marginTop="@dimen/tweet_harvesting_margin"
+            android:visibility="gone"/>
+
+        <ProgressBar
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:id="@+id/progress_bar"
+            android:layout_centerInParent="true" />
+
+    </RelativeLayout>
 
     <TextView
         android:layout_width="@dimen/message_width"


### PR DESCRIPTION
Circular progress bar is added in TweetHarvestingFragment and
SearchCategoryFragment. The progress bar is shown till data is fetched
from internet.

### After fix
**TweetHarvestingFragment**
![21057824_1931246250496099_327876403_o](https://user-images.githubusercontent.com/12163892/29549269-dcc0b270-8724-11e7-84d3-86a7628fb962.png)

**SearchCategoryFragment**
![21017891_1931246280496096_1892056432_o](https://user-images.githubusercontent.com/12163892/29549288-f28297b8-8724-11e7-8333-5ce218fd634f.png)

