### PR TITLE
Fixes #93: Use Vector Support Libraries

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,6 @@ File > New > Import Project > Locate build.gradle file in the cloned directory >
 * ButterKnife [docs](http://jakewharton.github.io/butterknife/javadoc/)
 * RxJava [docs](http://reactivex.io/RxJava/javadoc/)
 * RxAndroid [docs](https://www.javadoc.io/doc/io.reactivex/rxandroid/1.2.1)
-* Retrolambda [Github](https://github.com/orfjackal/retrolambda)
 * LiquidCore [docs](https://liquidplayer.github.io/LiquidCoreAndroid/0.2.2/)
 * Glide [docs](http://bumptech.github.io/glide/javadocs/images/360/index.html)
 

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -1,7 +1,6 @@
 apply plugin: 'com.android.application'
 // TODO: Uncomment to enable crashlytics
 // apply plugin: 'io.fabric'
-apply plugin: 'me.tatarka.retrolambda'
 apply plugin: 'realm-android'
 apply plugin: 'jacoco-android'
 
@@ -45,47 +44,47 @@ android {
 }
 
 dependencies {
-    compile fileTree(include: ['*.jar'], dir: 'libs')
+    implementation fileTree(include: ['*.jar'], dir: 'libs')
 
-    testCompile 'junit:junit:4.12'
-    testCompile 'org.assertj:assertj-core:1.7.1'
-    testCompile 'org.mockito:mockito-core:2.8.47'
-    testCompile 'com.android.support:support-annotations:25.3.1'
+    testImplementation 'junit:junit:4.12'
+    testImplementation 'org.assertj:assertj-core:1.7.1'
+    testImplementation 'org.mockito:mockito-core:2.8.47'
+    testImplementation 'com.android.support:support-annotations:25.3.1'
 
-    androidTestCompile 'org.mockito:mockito-android:2.8.47'
-    androidTestCompile 'com.android.support:support-annotations:25.3.1'
-    androidTestCompile 'com.android.support.test.espresso:espresso-core:2.2.2'
+    androidTestImplementation 'org.mockito:mockito-android:2.8.47'
+    androidTestImplementation 'com.android.support:support-annotations:25.3.1'
+    androidTestImplementation 'com.android.support.test.espresso:espresso-core:2.2.2'
 
-    compile 'com.android.support:appcompat-v7:25.3.1'
-    compile 'com.android.support:support-v4:25.3.1'
-    compile 'com.android.support:design:25.3.1'
-    compile 'com.android.support:cardview-v7:25.3.1'
+    implementation 'com.android.support:appcompat-v7:25.3.1'
+    implementation 'com.android.support:support-v4:25.3.1'
+    implementation 'com.android.support:design:25.3.1'
+    implementation 'com.android.support:cardview-v7:25.3.1'
 
-    compile 'org.joda:joda-convert:1.8'
-    compile 'joda-time:joda-time:2.9.4'
+    implementation 'org.joda:joda-convert:1.8'
+    implementation 'joda-time:joda-time:2.9.4'
 
-    compile 'com.google.code.gson:gson:2.8.1'
+    implementation 'com.google.code.gson:gson:2.8.1'
 
-    compile 'com.squareup.retrofit2:retrofit:2.3.0'
-    compile 'com.squareup.retrofit2:converter-gson:2.3.0'
-    compile 'com.squareup.okhttp3:logging-interceptor:3.7.0'
-    compile 'com.squareup.retrofit2:adapter-rxjava2:2.3.0'
+    implementation 'com.squareup.retrofit2:retrofit:2.3.0'
+    implementation 'com.squareup.retrofit2:converter-gson:2.3.0'
+    implementation 'com.squareup.okhttp3:logging-interceptor:3.7.0'
+    implementation 'com.squareup.retrofit2:adapter-rxjava2:2.3.0'
 
-    compile 'com.jakewharton:butterknife:8.6.0'
+    implementation 'com.jakewharton:butterknife:8.6.0'
     annotationProcessor 'com.jakewharton:butterknife-compiler:8.6.0'
 
-    compile 'com.google.dagger:dagger:2.11'
+    implementation 'com.google.dagger:dagger:2.11'
     annotationProcessor 'com.google.dagger:dagger-compiler:2.11'
 
-    compile 'io.reactivex.rxjava2:rxjava:2.0.5'
-    compile 'io.reactivex.rxjava2:rxandroid:2.0.1'
-    compile 'com.jakewharton.rxbinding2:rxbinding:2.0.0'
+    implementation 'io.reactivex.rxjava2:rxjava:2.0.5'
+    implementation 'io.reactivex.rxjava2:rxandroid:2.0.1'
+    implementation 'com.jakewharton.rxbinding2:rxbinding:2.0.0'
 
-    compile 'com.github.LiquidPlayer:LiquidCore:0.2.2'
+    implementation 'com.github.LiquidPlayer:LiquidCore:0.2.2'
 
-    compile 'com.github.bumptech.glide:glide:3.7.0'
+    implementation 'com.github.bumptech.glide:glide:3.7.0'
 
-    compile('com.crashlytics.sdk.android:crashlytics:2.6.8@aar') {
-        transitive = true;
+    implementation('com.crashlytics.sdk.android:crashlytics:2.6.8@aar') {
+        transitive = true
     }
 }

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -20,6 +20,7 @@ android {
         versionCode 1
         versionName "1"
         testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
+        vectorDrawables.useSupportLibrary = true
     }
     buildTypes {
         release {

--- a/build.gradle
+++ b/build.gradle
@@ -4,6 +4,7 @@ buildscript {
     repositories {
         jcenter()
         maven { url 'https://maven.fabric.io/public' }
+        google()
     }
     dependencies {
         classpath 'com.android.tools.build:gradle:3.0.1'

--- a/build.gradle
+++ b/build.gradle
@@ -6,7 +6,7 @@ buildscript {
         maven { url 'https://maven.fabric.io/public' }
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.3.3'
+        classpath 'com.android.tools.build:gradle:3.0.1'
         classpath 'me.tatarka:gradle-retrolambda:3.2.0'
         classpath "io.realm:realm-gradle-plugin:3.3.1"
         classpath 'com.dicedmelon.gradle:jacoco-android:0.1.1'

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Sun Jun 04 16:10:33 IST 2017
+#Mon Dec 11 14:29:30 IST 2017
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-3.3-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.1-all.zip


### PR DESCRIPTION
Configured the app to use vector support libraries by adding the `vectorDrawables` element to the `build.gradle` file in the `app` module.